### PR TITLE
Set default values correctly

### DIFF
--- a/src/components/Clock.js
+++ b/src/components/Clock.js
@@ -44,12 +44,12 @@ class Clock extends Component {
     super(props);
 
     /* Set Default Props Values */
-    this.props.config.id = this.props.config.id || `pixelfactory-${this.props.config.town}`;
-    this.props.config.locale = this.props.config.locale || 'en';
-    this.props.config.showTown = this.props.config.showTown || true;
-    this.props.config.showTimezone = this.props.config.showTimezone || true;
-    this.props.config.showDate = this.props.config.showDate || true;
-    this.props.config.meridiem = this.props.config.meridiem || false;
+    if (this.props.config.id === undefined) { this.props.config.id = `pixelfactory-${this.props.config.town}` }
+    if (this.props.config.locale === undefined) { this.props.config.locale = 'en' }
+    if (this.props.config.showTown === undefined) { this.props.config.showTown = true }
+    if (this.props.config.showTimezone === undefined) { this.props.config.showTimezone = true }
+    if (this.props.config.showDate === undefined) { this.props.config.showDate = true }
+    if (this.props.config.meridiem === undefined) { this.props.config.meridiem = false }
 
     /* Set Initlal State */
     this.state = {

--- a/test/components/Clock-config-test.js
+++ b/test/components/Clock-config-test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
+import {expect} from 'chai';
+import Clock from '../../src/components/Clock';
+
+describe('Clock Config: ', () => {
+  const config = {
+    town: 'Fort Collins',
+    timezone: 'America/Denver',
+    locale: 'en',
+    showTown: false,
+    showTimezone: false,
+    showDate: false
+  };
+
+  const shallowRenderer = ReactTestUtils.createRenderer();
+  shallowRenderer.render(<Clock config={config}/>);
+  const clock = shallowRenderer.getRenderOutput();
+
+  // Get Clock Element
+  it('clock should be a <div> container', () => {
+    expect(clock.type).to.equal('div');
+  });
+
+  // console.log(clock.props.children[0]);
+  // console.log(clock.props.children[1]);
+  // console.log(clock.props.children[2]);
+  // console.log(clock.props.children[3]);
+
+  // Town Should Be Null
+  const town = clock.props.children[0];
+  it('town should be null', () => {
+    expect(town).to.eql(null);
+  });
+
+  // Timezone Should Be Null
+  const timezone = clock.props.children[1];
+  it('timezone should be null', () => {
+    expect(timezone).to.eql(null);
+  });
+
+  // Date Should Be Null
+  const date = clock.props.children[3];
+  it('date should be null', () => {
+    expect(date).to.eql(null);
+  });
+
+});

--- a/test/components/Clock-test.js
+++ b/test/components/Clock-test.js
@@ -61,10 +61,10 @@ describe('Clock: ', () => {
   // console.log(clock.props.children[0]);
   // console.log(clock.props.children[1]);
   // console.log(clock.props.children[2]);
-  // console.log(clock.props.children[2]);
+  // console.log(clock.props.children[3]);
 
   // Test Town Element
-  const town = clock.props.children[0]
+  const town = clock.props.children[0];
   it('town should be a <h1> tag', () => {
     expect(town.type).to.eql('h1');
   });
@@ -76,7 +76,7 @@ describe('Clock: ', () => {
   });
 
   // Test Timezone Element
-  const timezone = clock.props.children[1]
+  const timezone = clock.props.children[1];
   it('timezone should be a <h2> tag', () => {
     expect(timezone.type).to.eql('h2');
   });
@@ -84,7 +84,7 @@ describe('Clock: ', () => {
     expect(timezone.props.className).to.eql('timezone');
   });
   it(`timezone should contain the text "${config.timezone} ${tz.toString()}`, () => {
-    expect(timezone.props.children.join('')).to.eql('Europe/Paris CET');
+    expect(timezone.props.children.join('')).to.eql('Europe/Paris CEST');
   });
 
   // Test Time Element
@@ -106,7 +106,7 @@ describe('Clock: ', () => {
   });
   it(`hours should equal "${h.toString()}"`, () => {
     expect(hours.props.children).to.eql(h.toString());
-  })
+  });
 
   // Test Points Element
   const points = time.props.children[1];
@@ -127,7 +127,7 @@ describe('Clock: ', () => {
   });
   it(`minutes should equal "${m.toString()}"`, () => {
     expect(minutes.props.children).to.eql(m.toString());
-  })
+  });
 
   // Test Sectional Element
   const sectional = time.props.children[3];


### PR DESCRIPTION
The default values were being set as such:

`this.props.config.showTown = this.props.config.showTown || true;`

So if the component's `showTown` parameter was set to false, then the config value in the constructor was set to `false || true` which evaluates to true.

(Unfortunately it looks like React's `defaultProps` only does a shallow merge, so that can't be used here?)

I added some tests to check that false values for showTown, showTimezone, and showDate are rendered correctly.

Also, one of the original tests was returning a timezone of 'CEST' instead of 'CET'. I'm not sure if that is just my environment, but I changed that also to get it to pass.

Nice code. Thanks!