### PR TITLE
Fix clock visibility in Storybook by adding dark background decorator

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/react-vite'
+import { createElement } from 'react'
 import '../src/styles/reset.css'
 import '../src/styles/main.css'
 import '../src/styles/theme.css'
@@ -24,7 +25,31 @@ const preview: Preview = {
         },
       ],
     },
+    // Apply dark theme to docs page
+    docs: {
+      story: {
+        inline: false,
+        iframeHeight: 400,
+      },
+    },
   },
+  decorators: [
+    (Story) =>
+      createElement(
+        'div',
+        {
+          style: {
+            background: '#000',
+            minHeight: '400px',
+            padding: '2rem',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          },
+        },
+        createElement(Story)
+      ),
+  ],
 };
 
 export default preview;


### PR DESCRIPTION
- Add global decorator to wrap all stories in dark container (#000 background)
- Ensures clock components (with white text) are visible on dark backgrounds
- Set docs.story.inline to false for proper iframe rendering
- Maintains dark background across all story views and docs page
- Import createElement from React for decorator implementation

Fixes issue where clocks were invisible (white text on white background) in the deployed Storybook at:
https://amine7536.github.io/react-clockwall/storybook/